### PR TITLE
GHRCCLOUD-5567: Update syntax for latest terraform version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -29,8 +29,8 @@ resource "aws_security_group" "mount_target_client" {
   depends_on = [aws_efs_mount_target.mount_target]
 
   tags = merge(
-    map("Name", "${var.name}-mount-target-client"),
-    map("terraform", "true"),
+    tomap({"Name" = "${var.name}-mount-target-client"}),
+    tomap({"terraform" = "true"}),
     var.tags,
   )
 }
@@ -51,8 +51,8 @@ resource "aws_security_group" "mount_target" {
   vpc_id      = var.vpc_id
 
   tags = merge(
-    map("Name", "${var.name}-mount-target"),
-    map("terraform", "true"),
+    tomap({"Name" = "${var.name}-mount-target"}),
+    tomap({"terraform" = "true"}),
     var.tags,
   )
 }


### PR DESCRIPTION
Latest terraform version deprecates map() and replaces with tomap({})